### PR TITLE
Fix for change username on upcoming OwnCast

### DIFF
--- a/src/content-script.js
+++ b/src/content-script.js
@@ -100,7 +100,8 @@ function autoChangeUsername() {
 			process.env.NODE_ENV === 'development' && console.log('[autoChangeUsername] got valid username')
 			
 			const usernameAlreadyStored = localStorage.getItem('owncast_username')
-			if (usernameAlreadyStored) {
+			const usernameCustom = localStorage.getItem('owncast_custom_username_set')
+			if (usernameAlreadyStored && usernameCustom) {
 				process.env.NODE_ENV === 'development' && console.log('[autoChangeUsername] found username', usernameAlreadyStored, 'associated with this instance - not changing username automatically')
 				return;
 			}

--- a/src/content-script.js
+++ b/src/content-script.js
@@ -99,10 +99,10 @@ function autoChangeUsername() {
 		if (username) {
 			process.env.NODE_ENV === 'development' && console.log('[autoChangeUsername] got valid username')
 			
-			const usernameAlreadyStored = localStorage.getItem('owncast_username')
-			const usernameCustom = localStorage.getItem('owncast_custom_username_set')
-			if (usernameAlreadyStored && usernameCustom) {
-				process.env.NODE_ENV === 'development' && console.log('[autoChangeUsername] found username', usernameAlreadyStored, 'associated with this instance - not changing username automatically')
+			const isCustomUsernameSet = localStorage.getItem('owncast_custom_username_set')
+			const potentialUsername = localStorage.getItem('owncast_username')
+			if (isCustomUsernameSet === 'true') {
+				process.env.NODE_ENV === 'development' && console.log('[autoChangeUsername] found username', potentialUsername, 'associated with this instance - not changing username automatically')
 				return;
 			}
 


### PR DESCRIPTION
In the upcoming OwnCast version is the chat username an autogenerated name and this name stored in the localstorage variable owncast_username. This change check additional the new variable owncast_custom_username_set.