### PR TITLE
background: dont show badge if no followed instance is online (#211)

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -94,8 +94,13 @@ const setBadge = async (instanceData) => {
 	const options = await Storage.getOptionsFromStorage()
 	if (options.badge) {
 		const online = instanceData.filter((a) => { return a.online })
-		await browser.browserAction.setBadgeBackgroundColor({ color: '#3d007a' })
-		await browser.browserAction.setBadgeText({ text: `${online.length}` })
+		if (online.length > 0) {
+			await browser.browserAction.setBadgeBackgroundColor({ color: '#3d007a' })
+			await browser.browserAction.setBadgeText({ text: `${online.length}` })
+		} else {
+			// hide the badge if no followed instances are online
+			await browser.browserAction.setBadgeText({ text: '' })
+		}
 	} else {
 		await browser.browserAction.setBadgeText({ text: '' })
 	}


### PR DESCRIPTION
This commit changes the badge behaviour. Before, a badge displaying a
'0' was shown if no instance was online. Now, no text is shown instead.
This makes it easier to notice if a channel goes online

Closes #211 